### PR TITLE
Allow log methods to be called on a nil logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -90,6 +90,11 @@ func New(level Level) (l *Logger) {
 }
 
 func (l *Logger) Printf(level Level, prefix, format string, v ...interface{}) {
+	if l == nil {
+		// nil logger - ignore
+		return
+	}
+
 	switch {
 	case level == Levels.Access:
 		count := atomic.AddUint64(&l.sampleCount, 1)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,18 @@
+package logger
+
+import (
+	"testing"
+)
+
+// TestNilLogger tests that you can safely call log methods on a nil logger.
+// This is convenient, for example, when you'd like to test code without
+// creating and passing in a logger.
+func TestNilLogger(t *testing.T) {
+	var log *Logger
+
+	log.Debugf("prefix", "Hello %s", "there")
+	log.Infof("prefix", "Hello %s", "there")
+	log.Warnf("prefix", "Hello %s", "there")
+	log.Errorf("prefix", "Hello %s", "there")
+	log.Panicf("prefix", "Hello %s", "there")
+}


### PR DESCRIPTION
This adds the convenience of being able to skip creating a logger
for code that expects one, but you don't need it - perhaps in
unit tests, etc.
