### PR TITLE
Milliseconds in log

### DIFF
--- a/logger/logger_writer.go
+++ b/logger/logger_writer.go
@@ -27,13 +27,14 @@ import "C"
 
 const (
 	NumMessages   = 10 * 1024 // number of allowed log messages
-	STDOUT_FORMAT = "2006-01-02T15:04:05 "
+	STDOUT_FORMAT = "2006-01-02T15:04:05.000 "
 )
 
 // container for a pending log message
 type logMessage struct {
 	bytes.Buffer
 	level C.int
+	time  time.Time
 }
 
 var (
@@ -146,6 +147,8 @@ func queueMsg(lvl Level, prefix, format string, v ...interface{}) (err error) {
 		return
 	}
 
+	msg.time = time.Now()
+
 	// render the message: level prefix, message body, C null terminator
 	msg.level = levelSysLog[lvl]
 	if _, err = msg.Write(levelMapFmt[lvl]); err != nil {
@@ -185,7 +188,7 @@ func printStdOut(msg *logMessage) (err error) {
 	// remove C null-termination byte
 	message := string(msg.Bytes()[:msg.Len()-1])
 	message = strings.TrimRight(message, "\n")
-	fmt.Fprintf(output, "%s%s%s\n", time.Now().Format(STDOUT_FORMAT), logNameString, message)
+	fmt.Fprintf(output, "%s%s%s\n", msg.time.Format(STDOUT_FORMAT), logNameString, message)
 	return
 }
 


### PR DESCRIPTION
Added the queueMsg error-path changes discussed with Dhammika on Friday -- I just dropped the "defer" we were discussing entirely, and moved freeMsg() calls out to the relevant error-handling blocks.