### PR TITLE
Optional structured logging to stdout

### DIFF
--- a/logger/format.go
+++ b/logger/format.go
@@ -1,0 +1,85 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type logEntryStructured struct {
+	Time    time.Time `json:"time"`
+	Level   string    `json:"level"`
+	Prefix  string    `json:"prefix"`
+	Message string    `json:"message"`
+	Caller  string    `json:"caller"`
+	LogName string    `json:"logName"`
+}
+
+const KentikLogFmt = "KENTIK_LOG_FMT"
+
+var sendJSON = true
+
+// setSendJSON is called by init. It sets sendJSON to `true`, if environment
+// variable KentikLogFmt is unset|empty|"json"|"JSON", `false` otherwise.
+func setSendJSON() {
+	logFormat := os.Getenv(KentikLogFmt)
+	sendJSON = logFormat == "" || strings.ToLower(logFormat) == "json"
+}
+
+// asString creates a JSON-structured string entry in the receiver's buffer.
+func (lm *logMessage) asJSON() error {
+	le := lm.le
+	les := logEntryStructured{
+		Time:    lm.time,
+		Level:   strings.ToLower(le.lvl.String()),
+		Prefix:  strings.Trim(le.pre, " "),
+		Message: fmt.Sprintf(le.fmt, le.fmtV...),
+		Caller:  le.lc.String(),
+		LogName: logNameString,
+	}
+	return json.NewEncoder(lm).Encode(les)
+}
+
+// asString creates a non-JSON log string entry in the receiver's buffer.
+//
+// It encapsulates most of the message formatting that was in queueMsg and some that was in printStd.
+func (lm *logMessage) asString() (err error) {
+	// for unknown reasons, only printStd pre-pended the time and log name
+	if stdhdl != nil {
+		_, err = fmt.Fprintf(lm, "%s%s", lm.time.Format(STDOUT_FORMAT), logNameString)
+		if err != nil {
+			return
+		}
+	}
+
+	// this is the equivalent formatting that was in queueMsg, excluding the C-string termination
+	le := lm.le
+	_, err = fmt.Fprintf(lm, "%s%s<%s: %d> ", levelMapFmt[le.lvl], le.pre, le.lc.File, le.lc.Line)
+	if err != nil {
+		return
+	}
+	if _, err = fmt.Fprintf(lm, le.fmt, le.fmtV...); err != nil {
+		return
+	}
+
+	// for unknown reasons, only printStd trimmed new lines
+	if stdhdl != nil {
+		lm.rightTrimNewLines()
+	}
+	return
+}
+
+// rightTrimNewLines trims off any/all '\n' from the end logMessage's buffer
+func (lm *logMessage) rightTrimNewLines() {
+	bs := lm.Bytes()
+	l := len(bs)
+	bsEnd := l - 1 // last index of bs
+	var cnt int
+	for cnt = 0; cnt < l && bs[bsEnd-cnt] == '\n'; cnt++ {
+	}
+	if cnt > 0 {
+		lm.Truncate(l - cnt)
+	}
+}

--- a/logger/format_test.go
+++ b/logger/format_test.go
@@ -35,7 +35,6 @@ var (
 func Test_asString(t *testing.T) {
 	stdhdl = io.Writer(os.Stdout)
 	_ = SetLogName(tLogName)
-	// defer reset
 
 	lm := &logMessage{le: le, time: tm}
 
@@ -46,7 +45,7 @@ func Test_asString(t *testing.T) {
 
 	levelStr := string(levelMapFmt[level])
 	caller := fmt.Sprintf("<%s: %d> ", le.lc.File, le.lc.Line)
-	logStr := tTime + tLogName + levelStr + le.pre + caller + msg
+	logStr := tTime + tLogName + levelStr + le.pre + caller + msg + "\n"
 	if logStr != lm.String() {
 		t.Errorf("%s != %s", logStr, lm.String())
 	}
@@ -70,7 +69,7 @@ func Test_asJSON(t *testing.T) {
 		Prefix:  "[CHF]",
 		Message: msg,
 		Caller:  le.lc.String(),
-		LogName: tLogName,
+		Name:    tLogName,
 	}
 	if expected != *actual {
 		t.Errorf("expected:%v != actual:%v", expected, *actual)
@@ -103,7 +102,7 @@ func Test_rightTrimNewLines(t *testing.T) {
 				t.Errorf("%q: Fprintf returned %v", tt.name, err)
 			}
 			lm.rightTrimNewLines()
-			trimmed := strings.TrimRight(tt.msg, "\n")
+			trimmed := strings.TrimRight(tt.msg, "\n") + "\n"
 			message := string(lm.Bytes())
 			if trimmed != message {
 				t.Errorf("%q: %s != %s", tt.name, trimmed, message)

--- a/logger/format_test.go
+++ b/logger/format_test.go
@@ -1,0 +1,162 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	tTime    = "2022-08-25T00:55:13.578 "
+	tLogName = "./kproxy [2189:versa_br2_our1:404055] [2510919]"
+)
+
+var (
+	level = Levels.Info
+	le    = logEntry{
+		lvl:  level,
+		pre:  "[CHF] ",
+		fmt:  "%q -> versa device",
+		fmtV: []interface{}{"versa appliance"},
+		lc: logCaller{
+			File: "/_/pkg/client/snmp/metrics/device_metrics.go",
+			Line: 115,
+		},
+	}
+	msg   = fmt.Sprintf(le.fmt, le.fmtV...)
+	tm, _ = time.Parse(STDOUT_FORMAT, tTime)
+)
+
+func Test_asString(t *testing.T) {
+	stdhdl = io.Writer(os.Stdout)
+	_ = SetLogName(tLogName)
+	// defer reset
+
+	lm := &logMessage{le: le, time: tm}
+
+	err := lm.asString()
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+	levelStr := string(levelMapFmt[level])
+	caller := fmt.Sprintf("<%s: %d> ", le.lc.File, le.lc.Line)
+	logStr := tTime + tLogName + levelStr + le.pre + caller + msg
+	if logStr != lm.String() {
+		t.Errorf("%s != %s", logStr, lm.String())
+	}
+}
+
+func Test_asJSON(t *testing.T) {
+	if err := SetLogName(tLogName); err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+	lm := &logMessage{le: le, time: tm}
+	if err := lm.asJSON(); err != nil {
+		t.Errorf("err: %v", err)
+	}
+
+	actual := &logEntryStructured{}
+	_ = json.NewDecoder(lm).Decode(actual)
+	expected := logEntryStructured{
+		Time:    tm,
+		Level:   "info",
+		Prefix:  "[CHF]",
+		Message: msg,
+		Caller:  le.lc.String(),
+		LogName: tLogName,
+	}
+	if expected != *actual {
+		t.Errorf("expected:%v != actual:%v", expected, *actual)
+	}
+}
+func Test_rightTrimNewLines(t *testing.T) {
+	msg := randString(100)
+	longMsg := randString(1000)
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{name: "trim 0", msg: msg},
+		{name: "trim 1", msg: msg + "\n"},
+		{name: "trim 3", msg: msg + "\n\n\n"},
+		{name: "with leader trim 0", msg: "\n\n\n" + msg},
+		{name: "with leader trim 1", msg: "\n\n" + msg + "\n"},
+		{name: "with leader trim 2", msg: "\n" + msg + "\n\n"},
+		{name: "empty trim 0", msg: ""},
+		{name: "empty trim 1", msg: "\n"},
+		{name: "empty trim n", msg: "\n\n\n\n\n\n\n\n\n"},
+		{name: "long trim 0", msg: longMsg},
+		{name: "long trim 1", msg: longMsg + "\n"},
+		{name: "long trim 4", msg: longMsg + "\n\n\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lm := &logMessage{Buffer: bytes.Buffer{}}
+			if _, err := fmt.Fprint(lm, tt.msg); err != nil {
+				t.Errorf("%q: Fprintf returned %v", tt.name, err)
+			}
+			lm.rightTrimNewLines()
+			trimmed := strings.TrimRight(tt.msg, "\n")
+			message := string(lm.Bytes())
+			if trimmed != message {
+				t.Errorf("%q: %s != %s", tt.name, trimmed, message)
+			}
+		})
+	}
+}
+
+func Test_setSendJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		envVarVal string
+		sendJSON  bool
+	}{
+		{name: "empty", envVarVal: "", sendJSON: true},
+		{name: "json", envVarVal: "json", sendJSON: true},
+		{name: "jSoN", envVarVal: "jSoN", sendJSON: true},
+		{name: "JSON", envVarVal: "JSON", sendJSON: true},
+		{name: "!json", envVarVal: "!json", sendJSON: false},
+		{name: "string", envVarVal: "string", sendJSON: false},
+		{name: "random", envVarVal: randString(4), sendJSON: false},
+		{name: "json prefix", envVarVal: "json" + randString(4), sendJSON: false},
+		{name: "JsOn inside", envVarVal: randString(4) + "JsOn" + randString(4), sendJSON: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv(KentikLogFmt, tt.envVarVal)
+			setSendJSON()
+			if sendJSON != tt.sendJSON {
+				t.Errorf("%s: expected:%v, actual:%v", tt.name, tt.sendJSON, sendJSON)
+			}
+		})
+	}
+
+	// last test: environment variable unset
+	_ = os.Unsetenv(KentikLogFmt)
+	setSendJSON()
+	if !sendJSON {
+		t.Errorf("unset %s: %v", KentikLogFmt, sendJSON)
+	}
+}
+
+func Benchmark_asJSON(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		lm := &logMessage{le: le, time: tm}
+		_ = lm.asJSON()
+	}
+}
+
+func Benchmark_asString(b *testing.B) {
+	stdhdl = io.Writer(os.Stdout)
+	for i := 0; i < b.N; i++ {
+		lm := &logMessage{le: le, time: tm}
+		_ = lm.asString()
+	}
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -25,6 +25,7 @@ func TestRemoveNewline(t *testing.T) {
 	defer func(origstdhdl io.Writer) { stdhdl = origstdhdl }(stdhdl)
 	buf := bytes.Buffer{}
 	stdhdl = &buf
+	sendJSON = false
 
 	log := New(Levels.Debug)
 
@@ -43,6 +44,7 @@ func TestClose(t *testing.T) {
 	defer func() { setup() }() // Set everything up again since we call Close()
 	buf := bytes.Buffer{}
 	stdhdl = &buf
+	sendJSON = false
 
 	log := New(Levels.Debug)
 	log.Debugf("", "testing123")

--- a/logger/logger_writer.go
+++ b/logger/logger_writer.go
@@ -221,10 +221,6 @@ func printTee(msg *logMessage) {
 
 // printStd prints msg to stdhdl
 func printStd(msg *logMessage) (err error) {
-	// add new line char
-	if err = msg.WriteByte('\n'); err != nil {
-		return
-	}
 	_, err = io.Copy(stdhdl, msg)
 	return
 }
@@ -232,9 +228,8 @@ func printStd(msg *logMessage) (err error) {
 // write function writes a message to syslog. This is a concrete, blocking event.
 func write(msg *logMessage) (err error) {
 	// terminate C string
-	if err = msg.WriteByte(0); err != nil {
-		return
-	}
+	_ = msg.WriteByte(0) // *Buffer.WriteByte always returns nil
+
 	start := (*C.char)(unsafe.Pointer(&msg.Bytes()[0]))
 	_, err = C.csyslog(C.LOG_USER|msg.level, start)
 	return
@@ -244,9 +239,7 @@ func write(msg *logMessage) (err error) {
 // This is a concrete, blocking event. Writes out using the syslog rfc5424 format.
 func writeCustomSocket(msg *logMessage) (err error) {
 	// terminate C string
-	if err = msg.WriteByte(0); err != nil {
-		return
-	}
+	_ = msg.WriteByte(0) // *Buffer.WriteByte always returns nil
 
 	_, err = customSock.Write(bytes.Join([][]byte{[]byte(fmt.Sprintf("<%d>", C.LOG_USER|msg.level)),
 		msg.Bytes()}, []byte("")))

--- a/logger/logger_writer.go
+++ b/logger/logger_writer.go
@@ -54,8 +54,12 @@ type logMessage struct {
 
 // logCaller stores where the logger public log method was called
 type logCaller struct {
-	File string `json:"file"`
-	Line int    `json:"line"`
+	File string
+	Line int
+}
+
+func (lc logCaller) String() string {
+	return fmt.Sprintf("%s:%d", lc.File, lc.Line)
 }
 
 // logEntry encapsulates all parameters to queueMsg
@@ -72,18 +76,18 @@ type logEntryStructured struct {
 	Time    time.Time `json:"time"`
 	Level   string    `json:"level"`
 	Prefix  string    `json:"prefix"`
-	Message string    `json:"msg"`
-	Caller  logCaller `json:"caller"`
+	Message string    `json:"message"`
+	Caller  string    `json:"caller"`
 }
 
 func (msg *logMessage) asJSON() ([]byte, error) {
 	le := msg.le
 	les := logEntryStructured{
 		Time:    msg.time,
-		Level:   le.lvl.String(),
-		Prefix:  le.pre,
+		Level:   strings.ToLower(le.lvl.String()),
+		Prefix:  strings.Trim(le.pre, " "),
 		Message: fmt.Sprintf(le.fmt, le.fmtV...),
-		Caller:  le.lc,
+		Caller:  le.lc.String(),
 	}
 	return json.Marshal(les)
 }


### PR DESCRIPTION
If the `KENTIK_LOG_FMT` environment variable is set to `json`, then
output a more structured log message.

Like so:
```json
{
  "time": "2022-08-31T13:30:00.954336665Z",
  "level": "info",
  "prefix": "[CHF]",
  "message": "Sending over http to [http://127.0.0.1:20012] -- Max conn Q: 1000",
  "caller": "/home/alistair/src/chf/pkg/client/packer.go:241"
}
```

More examples:
```json
{"time":"2022-08-31T13:30:00.954413342Z","level":"info","prefix":"[CHF]","message":"HTTP SendHttpRequest 3: online for 1013:er4_ipfix:1546","caller":"/home/alistair/src/chf/pkg/common/tx/http/http.go:229"}
{"time":"2022-08-31T13:30:00.954605158Z","level":"info","prefix":"[CHF]","message":"CHF Client UDP listener polling","caller":"/home/alistair/src/chf/pkg/client/listen/udp-listen.go:63"}
{"time":"2022-08-31T13:30:00.954635045Z","level":"info","prefix":"[CHF]","message":"CHF Client HTTP listener polling","caller":"/home/alistair/src/chf/pkg/client/listen/http-listen.go:108"}
{"time":"2022-08-31T13:30:00.954663109Z","level":"info","prefix":"[CHF]","message":"spawning 6 decoders\n","caller":"/home/alistair/src/chf/pkg/client/client.go:1172"}
{"time":"2022-08-31T13:30:00.954672927Z","level":"info","prefix":"[CHF]","message":"Starting low traffic loop @ 20m0s. Exit if no traffic in this time","caller":"/home/alistair/src/chf/pkg/client/client.go:1571"}
{"time":"2022-08-31T13:30:04.461727007Z","level":"info","prefix":"[CHF] [BGP]","message":"Received EOR: \u0026{TimeFloat:0 Neigh:{IP:::1 Msg:{Update:{Attribute:{ASPath:[] ASSet:[] ConfedPath:[] ConfedSet:[] Origin: Community:[] ExtCommunity:[] PrefixSid:{LabelIndex:0}} Announce:{IPs:map[] IP6s:map[] IPL3VPN:map[] IP6L3VPN:map[] IPMPLS:map[] IP6MPLS:map[]} Withdraw:{IPs:[] IP6s:[] IPL3VPN:[] IP6L3VPN:[] IPMPLS:[] IP6MPLS:[]} EOR:{AFI:ipv6 SAFI:unicast}}}} Notification:}","caller":"/home/alistair/src/chf/pkg/common/bgp/bgp.go:180"}
```